### PR TITLE
Empty config/settings.yml breaks discourse

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,67 @@
+plugins:
+  events_enabled:
+    default: false
+    client: true
+  events_agenda_enabled:
+    default: false
+    client: true
+  events_calendar_enabled:
+    default: false
+    client: true
+  events_add_to_calendar:
+    client: true
+    default: false
+  events_event_label_icon:
+    client: true
+    default: 'calendar'
+  events_event_label_no_text:
+    client: true
+    default: false
+  events_event_label_format:
+    client: true
+    default: 'MMMM Do, HH:mm'
+  events_event_label_short_format:
+    client: true
+    default: 'M-D, HH:mm'
+  events_event_label_short_only_start:
+    client: true
+    default: false
+  events_event_time_calendar_format:
+    client: true
+    default: 'HH:mm'
+  events_remove_past_from_agenda:
+    default: false
+  events_remove_past_from_map:
+    default: false
+  events_remove_past_from_calendar:
+    default: false
+  events_agenda_filter_closed:
+    default: false
+  events_calendar_filter_closed:
+    default: false
+  events_timezone_default:
+    default: ''
+    client: true
+    enum: 'EventsTimezoneDefaultSiteSetting'
+  events_timezone_event:
+    default: true
+    client: true
+  events_timezone_include_in_email:
+    default: true
+  events_timezone_format:
+    default: ''
+    client: true
+  events_timezone_rails_format:
+    default: true
+    client: true
+  events_hamburger_menu_calendar_link:
+    default: false
+    client: true
+  events_hamburger_menu_agenda_link:
+    default: false
+    client: true
+  events_min_trust_to_create:
+    default: 0
+  events_rsvp:
+    default: false
+    client: true


### PR DESCRIPTION
So when I made placeholder files, I put an empty file at
config/settings.yml. It turns out that breaks discourse locally.

This copies the config/settings.yml from discourse-events so that
we have non-empty, valid yml until we need to do something.