### PR TITLE
Create `discourse-ticketing` category in i18n, relocate existing keys  to abide by new standard.

### DIFF
--- a/assets/javascripts/discourse-ticketing/connectors/after-topic-footer-buttons/create-ticket-button.hbs
+++ b/assets/javascripts/discourse-ticketing/connectors/after-topic-footer-buttons/create-ticket-button.hbs
@@ -2,7 +2,6 @@
   d-button class="assign"
   icon="user-plus"
   action="convertToTicket"
-  label="topics.create_ticket_label"
-  title="topics.create_ticket_help"
-
+  label="discourse_ticketing.topics.create_ticket_label"
+  title="discourse_ticketing.topics.create_ticket_help"
 }}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,7 +1,6 @@
 en:
   js:
-    ticketing:
-      title: "Discourse Ticketing"
-    topics:
-      create_ticket_label: "Create Ticket"
-      create_ticket_help: "Convert topic to ticket and set its priority, status, and assignment."
+    discourse_ticketing:
+      topics:
+        create_ticket_label: "Create Ticket"
+        create_ticket_help: "Convert topic to ticket and set its priority, status, and assignment."


### PR DESCRIPTION
We just want everything here to be scoped to the plugin's namespaced to avoid conflicts with other plugins.